### PR TITLE
Use bundled icon rather than themed icon, needed for 18.04

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -60,10 +60,16 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version $(git describe --tags --abbrev=10)
+    override-build: |
       # valadoc fails, but we don't need it in the snap anyway
       sed -i.bak -e "s|subdir('doc')||g" $SNAPCRAFT_PART_SRC/meson.build
       # Don't symlink media it leaves dangling symlinks in the snap
       sed -i.bak -e 's|media: gnome_calculator_help_media|media: gnome_calculator_help_media, symlink_media: false|g' $SNAPCRAFT_PART_SRC/help/meson.build
+      # Use bundled icon rather than themed icon, needed for 18.04
+      sed -i.bak -e 's|Icon=org.gnome.Calculator$|Icon=${SNAP}/meta/gui/org.gnome.Calculator.svg|g' $SNAPCRAFT_PART_SRC/data/org.gnome.Calculator.desktop.in
+      mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
+      cp $SNAPCRAFT_PART_SRC/data/icons/hicolor/scalable/apps/org.gnome.Calculator.svg $SNAPCRAFT_PART_INSTALL/meta/gui/
+      snapcraftctl build
 
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap


### PR DESCRIPTION
## Description

Use bundled icon rather than themed icon, needed for 18.04

## Type of change

Please check only the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:

* OS hirsute and bionic
* Any other relevant environment information: This fix is important for bionic (18.04) uses as it addresses the icon naming issues with the icon theme, which had renames post 18.04.  So testing on 18.04 is important.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

