### PR TITLE
Removed unneeded dependency

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,10 +56,8 @@ parts:
   libraries:
     plugin: nil
     stage-packages:
-      - libgtksourceview-4-0
       - libadwaita-1-0
     prime:
-      - usr/lib/*/libgtksource*
       - usr/lib/*/libadwaita*
 
   gnome-calculator:
@@ -78,7 +76,6 @@ parts:
       - libmpc-dev
       - libmpfr-dev
       - libgvc6
-      - libgtksourceview-4-dev
       - libadwaita-1-dev
     override-pull: |
       craftctl default


### PR DESCRIPTION
libgtksourceview isn't needed for gnome-calculator.

- [ ] New feature (non-breaking change which adds functionality)

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

