### PR TITLE
Migration to Core22

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -22,7 +22,7 @@ description: |
 
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core20
+base: core22
 
 slots:
   # for GtkApplication registration
@@ -34,7 +34,7 @@ slots:
 apps:
   gnome-calculator:
     command: usr/bin/gnome-calculator
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     plugs:
       - gsettings
       - network
@@ -45,11 +45,12 @@ apps:
 parts:
   gnome-calculator:
     source: https://gitlab.gnome.org/GNOME/gnome-calculator.git
-    source-branch: 'gnome-41'
+    source-tag: '42.1'
     plugin: meson
     meson-parameters:
       - --prefix=/snap/gnome-calculator/current/usr
-      - -Dvala_args="--vapidir=$SNAPCRAFT_STAGE/usr/share/vala/vapi"
+      - --buildtype=release
+      - -Dvala_args="--vapidir=$CRAFT_STAGE/usr/share/vala/vapi"
       - -Ddisable-introspection=true
     organize:
       snap/gnome-calculator/current/usr: usr
@@ -58,27 +59,27 @@ parts:
       - libmpfr-dev
       - libgvc6
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --abbrev=10)
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=10)
     override-build: |
       # valadoc fails, but we don't need it in the snap anyway
-      sed -i.bak -e "s|subdir('doc')||g" $SNAPCRAFT_PART_SRC/meson.build
+      sed -i.bak -e "s|subdir('doc')||g" $CRAFT_PART_SRC/meson.build
       # Don't symlink media it leaves dangling symlinks in the snap
-      sed -i.bak -e 's|media: gnome_calculator_help_media|media: gnome_calculator_help_media, symlink_media: false|g' $SNAPCRAFT_PART_SRC/help/meson.build
+      sed -i.bak -e 's|media: gnome_calculator_help_media|media: gnome_calculator_help_media, symlink_media: false|g' $CRAFT_PART_SRC/help/meson.build
       # Use bundled icon rather than themed icon, needed for 18.04
-      sed -i.bak -e 's|Icon=org.gnome.Calculator$|Icon=${SNAP}/meta/gui/org.gnome.Calculator.svg|g' $SNAPCRAFT_PART_SRC/data/org.gnome.Calculator.desktop.in
-      mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
-      cp $SNAPCRAFT_PART_SRC/data/icons/hicolor/scalable/apps/org.gnome.Calculator.svg $SNAPCRAFT_PART_INSTALL/meta/gui/
-      snapcraftctl build
+      sed -i.bak -e 's|Icon=org.gnome.Calculator$|Icon=${SNAP}/meta/gui/org.gnome.Calculator.svg|g' $CRAFT_PART_SRC/data/org.gnome.Calculator.desktop.in
+      mkdir -p $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_SRC/data/icons/hicolor/scalable/apps/org.gnome.Calculator.svg $CRAFT_PART_INSTALL/meta/gui/
+      craftctl default
 
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap
   cleanup:
     after: [gnome-calculator]
     plugin: nil
-    build-snaps: [core20, gtk-common-themes, gnome-3-38-2004/latest/candidate]
+    build-snaps: [core22, gtk-common-themes, gnome-42-2204]
     override-prime: |
       set -eux
-      for snap in "core20" "gtk-common-themes" "gnome-3-38-2004"; do
-        cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+      for snap in "core22" "gtk-common-themes" "gnome-42-2204"; do
+        cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$CRAFT_PRIME/{}" \;
       done

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
     source: https://gitlab.gnome.org/GNOME/gnome-calculator.git
     source-tag: '42.1'
     plugin: meson
+    parse-info: [usr/share/metainfo/org.gnome.Calculator.appdata.xml]
     meson-parameters:
       - --prefix=/snap/gnome-calculator/current/usr
       - --buildtype=release

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,7 +45,7 @@ apps:
 parts:
   gnome-calculator:
     source: https://gitlab.gnome.org/GNOME/gnome-calculator.git
-    source-tag: '42.1'
+    source-tag: '42.2'
     plugin: meson
     parse-info: [usr/share/metainfo/org.gnome.Calculator.appdata.xml]
     meson-parameters:


### PR DESCRIPTION
This patch takes advantage of having libadwaita in Gnome-42-2204-SDK. Thus it requires https://github.com/ubuntu/gnome-sdk/pull/37

# Pull Request Template

## Description

This MR migrates Gnome Calculator to Core22, and takes advantage of having libadwaita in the SDK. It requires https://github.com/ubuntu/gnome-sdk/pull/37.

Fixes # (issue)

DT-440

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

