### PR TITLE
Update to 48

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,11 +45,11 @@ apps:
 parts:
   gnome-calculator:
     source: https://gitlab.gnome.org/GNOME/gnome-calculator.git
-    source-tag: '46.1'
+    source-tag: '48.0.2'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '47'
+#     lower-than: '49'
 #     no-9x-revisions: true
 #     format: "%M.%m"
     plugin: meson


### PR DESCRIPTION
Upstream updated the gtk and libadwaita requirements but the needed versions are available in the current 46 sdk.
The new version builds and runs without issue locally